### PR TITLE
Add Less'ish fade() function

### DIFF
--- a/lib/flat-ui-sass/sass_functions.rb
+++ b/lib/flat-ui-sass/sass_functions.rb
@@ -36,6 +36,16 @@ module Sass::Script::Functions
       mix(white, color, percentage)
     end
   end
+  
+  unless Sass::Script::Functions.instance_methods.include?(:fade)
+    def fade(color, amount)
+      if amount.is_a?(Sass::Script::Number) && amount.unit_str == "%"
+        amount = Sass::Script::Number.new(1 - amount.value / 100.0)
+      end
+      fade_out(color, amount)
+    end
+    declare :fade, [:color, :amount]
+  end
 
   # Based on https://github.com/edwardoriordan/sass-utilities/blob/master/lib/sass-utilities.rb
   def interpolate_variable(name)


### PR DESCRIPTION
I came across this when using the `.navbar-embossed`. The converted less files have quite a few [fade](http://www.lesscss.org/#reference) functions. To complicate things, there is even one place where it uses a decimal vs the proper percentage that Less requires. This function handles that situation too. It is odd in that it has to flip the value that is passed down to Sass's [fade_out](http://sass-lang.com/documentation/Sass/Script/Functions.html#transparentize-instance_method) function. I tested my compiled out both visually and within the code – a perfect match to the pre-compiled flat-ui-pro.
