### PR TITLE
Sass 32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Flat-UI uses the [Lato](https://www.google.com/fonts/specimen/Lato)
 font as its base font. This gem does not vendor Lato. It is up to you to make
 sure Lato is available on your page.
 
+#### Notice:
+
+The preferred version of sass is v3.3.0+. Unfortunately, this version is not
+supported by sass-rails >= v4.0.2. If you run on sass v3.2.x, the only thing
+that will not work properly is the color swatch module in Flat-UI Free. The only
+other difference is in how the Flat-UI asset helper is discovered (see
+`_variables.scss`).
+
 ## Installation
 
 ### Rails

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Rails, Compass, and vanilla SASS.
 
 ## Dependencies
 
-`flat-ui-sass` requires [`bootstrap-sass`](https://github.com/twbs/bootstrap-sass) as well as `sass >= 3.3.0.rc.2`.
+`flat-ui-sass` requires [`bootstrap-sass`](https://github.com/twbs/bootstrap-sass)
 
 `flat-ui-sass` depends on `term-ansicolor` right now for the logging
 functionality of the converter. This is on the roadmap for removal.

--- a/flat-ui-sass.gemspec
+++ b/flat-ui-sass.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bootstrap-sass", ">= 3.1"
-  spec.add_dependency "sass", "~> 3.3.0"
+  spec.add_dependency "sass", ">= 3.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/flat-ui-sass/sass_functions.rb
+++ b/lib/flat-ui-sass/sass_functions.rb
@@ -48,8 +48,9 @@ module Sass::Script::Functions
   end
 
   # Based on https://github.com/edwardoriordan/sass-utilities/blob/master/lib/sass-utilities.rb
+  # For Sass < 3.3.0, just echo back the variable since we can't interpolate it
   def interpolate_variable(name)
     assert_type name, :String
-    environment.var(name.value)
+    ::Sass::VERSION >= '3.3.0' ? environment.var(name.value) : name
   end
 end

--- a/lib/tasks/converter.rb
+++ b/lib/tasks/converter.rb
@@ -19,6 +19,7 @@ require 'json'
 require 'fileutils'
 require 'term/ansicolor'
 require 'forwardable'
+require 'sass'
 
 # Pull in stuff from bootstrap-sass
 spec = Bundler.load.specs.find{|s| s.name == 'bootstrap-sass'}

--- a/lib/tasks/converter/flat_ui_less_conversion.rb
+++ b/lib/tasks/converter/flat_ui_less_conversion.rb
@@ -70,13 +70,20 @@ class Converter
             file = convert_grid_mixins file
           when 'variables.less'
             file = insert_default_vars(file)
-            file = unindent <<-SCSS + file, 14
+            if ::Sass::VERSION >= '3.3.0'
+              file = unindent <<-SCSS + file, 14
               // a flag to toggle asset pipeline / compass integration
-              // defaults to true if twbs-font-path function is present (no function => twbs-font-path('') parsed as string == right side)
-              // in Sass 3.3 this can be improved with: function-exists(twbs-font-path)
               $flat-ui-sass-asset-helper: function-exists(flat-ui-font-path) !default;
 
-            SCSS
+              SCSS
+            else
+              file = unindent <<-SCSS + file, 14
+              // a flag to toggle asset pipeline / compass integration
+              // defaults to true if flat-ui-font-path function is present (no function => twbs-font-path('') parsed as string == right side)
+              $flat-ui-sass-asset-helper: (flat-ui-font-path("") != unquote('flat-ui-font-path("")')) !default;
+
+              SCSS
+            end
             file = fix_variable_declaration_order file
             file = replace_all file, /(\$icon-font-path:\s+).*(!default)/, '\1"'+@output_dir+'/" \2'
           when 'modules/buttons.less'

--- a/vendor/assets/stylesheets/flat-ui/_variables.scss
+++ b/vendor/assets/stylesheets/flat-ui/_variables.scss
@@ -1,7 +1,6 @@
 // a flag to toggle asset pipeline / compass integration
-// defaults to true if twbs-font-path function is present (no function => twbs-font-path('') parsed as string == right side)
-// in Sass 3.3 this can be improved with: function-exists(twbs-font-path)
-$flat-ui-sass-asset-helper: function-exists(flat-ui-font-path) !default;
+// defaults to true if flat-ui-font-path function is present (no function => twbs-font-path('') parsed as string == right side)
+$flat-ui-sass-asset-helper: (flat-ui-font-path("") != unquote('flat-ui-font-path("")')) !default;
 
 //
 // Variables


### PR DESCRIPTION
Drops minimum required sass version to v3.2.0. Changes vendored version of flat-ui-free to be v3.2.x compatible.

Resolves #15 
