### PR TITLE
Don't load rake task unless on a supported Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ paths:
 
 ### Converting Flat-UI Pro
 
+**NOTE:** Support for Flat-UI Pro (and converting to SASS) is currently only available under MRI 2.0 and above.
+Users on other Ruby versions can still use Flat-UI Free.
+
 You can use the `fui_convert` command packaged along with `flat-ui-sass` to
 automatically convert and vendor Flat-UI Pro to your local application:
 

--- a/lib/tasks/flat-ui-sass.rake
+++ b/lib/tasks/flat-ui-sass.rake
@@ -1,8 +1,10 @@
-require_relative './converter'
-
-namespace :flat_ui_pro do
-  desc "Converts Flat UI Pro from LESS to SASS and vendors it"
-  task :convert do |t, args|
-    Converter.new(:pro, './flat-ui-pro').process_flat_ui!
+if RUBY_VERSION.to_i > 1 && RUBY_ENGINE == 'ruby'
+  require_relative './converter'
+  
+  namespace :flat_ui_pro do
+    desc "Converts Flat UI Pro from LESS to SASS and vendors it"
+    task :convert do |t, args|
+      Converter.new(:pro, './flat-ui-pro').process_flat_ui!
+    end
   end
 end


### PR DESCRIPTION
The `flatui-pro:convert` Rake task is the only one in this gem (or `bootstrap-sass`) that gets loaded directly into the Rails app.

It depends on several scripts in `bootstrap-sass` that otherwise don't get loaded. [One of these](https://github.com/twbs/bootstrap-sass/blob/master/tasks/converter/less_conversion.rb#L174) uses keyword arguments, a language feature only supported on MRI 2.x.

This wraps the loading of the Rake task in a conditional, so people still on MRI 1.9.3 (or other rubies, like Rubinius) can still use the rest of the gem. 
